### PR TITLE
test(spanner): add the support for running spanner integration tests with PostgreSQL dialect

### DIFF
--- a/spanner/integration_test.go
+++ b/spanner/integration_test.go
@@ -199,10 +199,6 @@ var (
 	blackholeDpv4Cmd string
 	allowDpv6Cmd     string
 	allowDpv4Cmd     string
-
-	supportedPGTests = map[string]bool{
-		"TestIntegration_SingleUse": true,
-	}
 )
 
 func init() {
@@ -409,7 +405,7 @@ loop:
 
 // Test SingleUse transaction.
 func TestIntegration_SingleUse(t *testing.T) {
-	skipUnsupportedPGTest(t)
+	skipEmulatorTestForPG(t)
 	t.Parallel()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
@@ -3783,12 +3779,15 @@ func skipEmulatorTest(t *testing.T) {
 	}
 }
 
+func skipEmulatorTestForPG(t *testing.T) {
+	if isEmulatorEnvSet() && testDialect == adminpb.DatabaseDialect_POSTGRESQL {
+		t.Skip("Skipping PG testing against the emulator.")
+	}
+}
+
 func skipUnsupportedPGTest(t *testing.T) {
 	if testDialect == adminpb.DatabaseDialect_POSTGRESQL {
-		skipEmulatorTest(t)
-		if _, ok := supportedPGTests[t.Name()]; !ok {
-			t.Skip("Skipping testing of unsupported tests in Postgres dialect.")
-		}
+		t.Skip("Skipping testing of unsupported tests in Postgres dialect.")
 	}
 }
 

--- a/spanner/integration_test.go
+++ b/spanner/integration_test.go
@@ -3256,7 +3256,7 @@ func TestIntegration_BatchDML_Error(t *testing.T) {
 }
 
 func TestIntegration_PGNumeric(t *testing.T) {
-	skipUnsupportedPGTest(t)
+	onlyRunForPGTest(t)
 	skipEmulatorTest(t)
 	t.Parallel()
 
@@ -3788,6 +3788,12 @@ func skipEmulatorTestForPG(t *testing.T) {
 func skipUnsupportedPGTest(t *testing.T) {
 	if testDialect == adminpb.DatabaseDialect_POSTGRESQL {
 		t.Skip("Skipping testing of unsupported tests in Postgres dialect.")
+	}
+}
+
+func onlyRunForPGTest(t *testing.T) {
+	if testDialect != adminpb.DatabaseDialect_POSTGRESQL {
+		t.Skip("Skipping tests supported only in Postgres dialect.")
 	}
 }
 

--- a/spanner/integration_test.go
+++ b/spanner/integration_test.go
@@ -54,7 +54,7 @@ const (
 	directPathIPV6Prefix = "[2001:4860:8040"
 	directPathIPV4Prefix = "34.126"
 
-	singerDBDDLStatements = "SINGER_DB__DDL_STATEMENTS"
+	singerDDLStatements = "SINGER_DDL_STATEMENTS"
 )
 
 var (
@@ -197,10 +197,10 @@ var (
 
 	statements = map[adminpb.DatabaseDialect]map[string][]string{
 		adminpb.DatabaseDialect_GOOGLE_STANDARD_SQL: {
-			singerDBDDLStatements: singerDBStatements,
+			singerDDLStatements: singerDBStatements,
 		},
 		adminpb.DatabaseDialect_POSTGRESQL: {
-			singerDBDDLStatements: singerDBPGStatements,
+			singerDDLStatements: singerDBPGStatements,
 		},
 	}
 
@@ -422,7 +422,7 @@ func TestIntegration_SingleUse(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
-	client, _, cleanup := prepareIntegrationTest(ctx, t, DefaultSessionPoolConfig, statements[testDialect][singerDBDDLStatements])
+	client, _, cleanup := prepareIntegrationTest(ctx, t, DefaultSessionPoolConfig, statements[testDialect][singerDDLStatements])
 	defer cleanup()
 
 	writes := []struct {


### PR DESCRIPTION
* Refactored code to run all integration test with both GOOGLE_STANDARD_SQL and POSTGRESQL dialect.
* Updated "TestIntegration_SingleUse" test to run with POSTGRESQL dialect.