### PR TITLE
test: changes for test_annotation IT tests

### DIFF
--- a/spanner/integration_test.go
+++ b/spanner/integration_test.go
@@ -2809,7 +2809,7 @@ func TestIntegration_DML(t *testing.T) {
 		return got
 	}
 
-	singersQuery := [7]string{`INSERT INTO Singers (SingerId, FirstName, LastName) VALUES (1, "Umm", "Kulthum")`,
+	singersQuery := []string{`INSERT INTO Singers (SingerId, FirstName, LastName) VALUES (1, "Umm", "Kulthum")`,
 		`INSERT INTO Singers (SingerId, FirstName, LastName) VALUES (2, "Eduard", "Khil")`,
 		`INSERT INTO Singers (SingerId, FirstName, LastName) VALUES (3, "Audra", "McDonald")`,
 		`UPDATE Singers SET FirstName = "Oum" WHERE SingerId = 1`,
@@ -2819,7 +2819,7 @@ func TestIntegration_DML(t *testing.T) {
 	}
 
 	if testDialect == adminpb.DatabaseDialect_POSTGRESQL {
-		singersQuery = [7]string{`INSERT INTO Singers (SingerId, FirstName, LastName) VALUES (1, 'Umm', 'Kulthum')`,
+		singersQuery = []string{`INSERT INTO Singers (SingerId, FirstName, LastName) VALUES (1, 'Umm', 'Kulthum')`,
 			`INSERT INTO Singers (SingerId, FirstName, LastName) VALUES (2, 'Eduard', 'Khil')`,
 			`INSERT INTO Singers (SingerId, FirstName, LastName) VALUES (3, 'Audra', 'McDonald')`,
 			`UPDATE Singers SET FirstName = 'Oum' WHERE SingerId = 1`,
@@ -3207,13 +3207,13 @@ func TestIntegration_BatchDML(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	singersQuery := [3]string{`UPDATE Singers SET Singers.FirstName = "changed 1" WHERE Singers.SingerId = 1`,
+	singersQuery := []string{`UPDATE Singers SET Singers.FirstName = "changed 1" WHERE Singers.SingerId = 1`,
 		`UPDATE Singers SET Singers.FirstName = "changed 2" WHERE Singers.SingerId = 2`,
 		`UPDATE Singers SET Singers.FirstName = "changed 3" WHERE Singers.SingerId = 3`,
 	}
 
 	if testDialect == adminpb.DatabaseDialect_POSTGRESQL {
-		singersQuery = [3]string{`UPDATE Singers SET FirstName = 'changed 1' WHERE SingerId = 1`,
+		singersQuery = []string{`UPDATE Singers SET FirstName = 'changed 1' WHERE SingerId = 1`,
 			`UPDATE Singers SET FirstName = 'changed 2' WHERE SingerId = 2`,
 			`UPDATE Singers SET FirstName = 'changed 3' WHERE SingerId = 3`,
 		}
@@ -3296,13 +3296,13 @@ func TestIntegration_BatchDML_TwoStatements(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	singersQuery := [4]string{`UPDATE Singers SET Singers.FirstName = "changed 1" WHERE Singers.SingerId = 1`,
+	singersQuery := []string{`UPDATE Singers SET Singers.FirstName = "changed 1" WHERE Singers.SingerId = 1`,
 		`UPDATE Singers SET Singers.FirstName = "changed 2" WHERE Singers.SingerId = 2`,
 		`UPDATE Singers SET Singers.FirstName = "changed 3" WHERE Singers.SingerId = 3`,
 		`UPDATE Singers SET Singers.FirstName = "changed 1" WHERE Singers.SingerId = 1`}
 
 	if testDialect == adminpb.DatabaseDialect_POSTGRESQL {
-		singersQuery = [4]string{`UPDATE Singers SET FirstName = 'changed 1' WHERE SingerId = 1`,
+		singersQuery = []string{`UPDATE Singers SET FirstName = 'changed 1' WHERE SingerId = 1`,
 			`UPDATE Singers SET FirstName = 'changed 2' WHERE SingerId = 2`,
 			`UPDATE Singers SET FirstName = 'changed 3' WHERE SingerId = 3`,
 			`UPDATE Singers SET FirstName = 'changed 1' WHERE SingerId = 1`}
@@ -3357,12 +3357,12 @@ func TestIntegration_BatchDML_Error(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	singersQuery := [3]string{`UPDATE Singers SET Singers.FirstName = "changed 1" WHERE Singers.SingerId = 1`,
+	singersQuery := []string{`UPDATE Singers SET Singers.FirstName = "changed 1" WHERE Singers.SingerId = 1`,
 		`some illegal statement`,
 		`UPDATE Singers SET Singers.FirstName = "changed 3" WHERE Singers.SingerId = 3`}
 
 	if testDialect == adminpb.DatabaseDialect_POSTGRESQL {
-		singersQuery = [3]string{`UPDATE Singers SET FirstName = 'changed 1' WHERE SingerId = 1`,
+		singersQuery = []string{`UPDATE Singers SET FirstName = 'changed 1' WHERE SingerId = 1`,
 			`some illegal statement`,
 			`UPDATE Singers SET FirstName = 'changed 3' WHERE SingerId = 3`}
 	}

--- a/spanner/integration_test.go
+++ b/spanner/integration_test.go
@@ -54,11 +54,11 @@ const (
 	directPathIPV6Prefix = "[2001:4860:8040"
 	directPathIPV4Prefix = "34.126"
 
-	singerDDLStatements = "SINGER_DDL_STATEMENTS"
-	simpleDDLStatements = "SIMPLE_DDL_STATEMENTS"
-	readDDLStatements   = "READ_DDL_STATEMENTS"
-	backupDDLStatements = "BACKUP_DDL_STATEMENTS"
-  testTableDDLStatements = "TEST_TABLE_DDL_STATEMENTS"
+	singerDDLStatements    = "SINGER_DDL_STATEMENTS"
+	simpleDDLStatements    = "SIMPLE_DDL_STATEMENTS"
+	readDDLStatements      = "READ_DDL_STATEMENTS"
+	backupDDLStatements    = "BACKUP_DDL_STATEMENTS"
+	testTableDDLStatements = "TEST_TABLE_DDL_STATEMENTS"
 )
 
 var (
@@ -249,18 +249,18 @@ var (
 
 	statements = map[adminpb.DatabaseDialect]map[string][]string{
 		adminpb.DatabaseDialect_GOOGLE_STANDARD_SQL: {
-			singerDDLStatements: singerDBStatements,
-			simpleDDLStatements: simpleDBStatements,
-			readDDLStatements:   readDBStatements,
-			backupDDLStatements: backupDBStatements,
-      testTableDDLStatements: readDBStatements,
+			singerDDLStatements:    singerDBStatements,
+			simpleDDLStatements:    simpleDBStatements,
+			readDDLStatements:      readDBStatements,
+			backupDDLStatements:    backupDBStatements,
+			testTableDDLStatements: readDBStatements,
 		},
 		adminpb.DatabaseDialect_POSTGRESQL: {
-			singerDDLStatements: singerDBPGStatements,
-			simpleDDLStatements: simpleDBPGStatements,
-			readDDLStatements:   readDBPGStatements,
-			backupDDLStatements: backupDBPGStatements,
-      testTableDDLStatements: readDBSPGtatements,
+			singerDDLStatements:    singerDBPGStatements,
+			simpleDDLStatements:    simpleDBPGStatements,
+			readDDLStatements:      readDBPGStatements,
+			backupDDLStatements:    backupDBPGStatements,
+			testTableDDLStatements: readDBSPGtatements,
 		},
 	}
 
@@ -2810,22 +2810,22 @@ func TestIntegration_DML(t *testing.T) {
 	}
 
 	singersQuery := [7]string{`INSERT INTO Singers (SingerId, FirstName, LastName) VALUES (1, "Umm", "Kulthum")`,
-		`Insert INTO Singers (SingerId, FirstName, LastName) VALUES (2, "Eduard", "Khil")`,
+		`INSERT INTO Singers (SingerId, FirstName, LastName) VALUES (2, "Eduard", "Khil")`,
 		`INSERT INTO Singers (SingerId, FirstName, LastName) VALUES (3, "Audra", "McDonald")`,
 		`UPDATE Singers SET FirstName = "Oum" WHERE SingerId = 1`,
 		`UPDATE Singers SET FirstName = "Eddie" WHERE SingerId = 2`,
 		`INSERT INTO Singers (SingerId, FirstName, LastName) VALUES (3, "Audra", "McDonald")`,
-		`SELECT FirstName from Singers`,
+		`SELECT FirstName FROM Singers`,
 	}
 
 	if testDialect == adminpb.DatabaseDialect_POSTGRESQL {
 		singersQuery = [7]string{`INSERT INTO Singers (SingerId, FirstName, LastName) VALUES (1, 'Umm', 'Kulthum')`,
-			`Insert INTO Singers (SingerId, FirstName, LastName) VALUES (2, 'Eduard', 'Khil')`,
+			`INSERT INTO Singers (SingerId, FirstName, LastName) VALUES (2, 'Eduard', 'Khil')`,
 			`INSERT INTO Singers (SingerId, FirstName, LastName) VALUES (3, 'Audra', 'McDonald')`,
 			`UPDATE Singers SET FirstName = 'Oum' WHERE SingerId = 1`,
 			`UPDATE Singers SET FirstName = 'Eddie' WHERE SingerId = 2`,
 			`INSERT INTO Singers (SingerId, FirstName, LastName) VALUES (3, 'Audra', 'McDonald')`,
-			`SELECT FirstName from Singers`,
+			`SELECT FirstName FROM Singers`,
 		}
 	}
 	// Use ReadWriteTransaction.Query to execute a DML statement.


### PR DESCRIPTION
Adding changes in the following test cases:
1. TestIntegration_BatchDML_Error
2. TestIntegration_BatchDML_TwoStatements
3. TestIntegration_BatchDML_NoStatements
4. TestIntegration_BatchDML
5. TestIntegration_PDML
6. TestIntegration_DML
7. TestIntegration_BROTNormal
8. TestIntegration_BatchQuery
9. TestIntegration_ReadErrors
10. TestIntegration_TransactionRunner
11. TestIntegration_BatchRead
12. TestIntegration_InvalidDatabase
13. TestIntegration_QueryStats
14. TestIntegration_QueryExpressions
15. TestIntegration_DirectPathFallback
16. TestIntegration_StartBackupOperation
